### PR TITLE
Changed the sign before 'logdet_sigma' in line 240

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -237,7 +237,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
                 s += 0.5 * (n_features * log(lambda_) +
                             n_samples * log(alpha_) -
                             alpha_ * rmse_ -
-                            (lambda_ * np.sum(coef_ ** 2)) -
+                            (lambda_ * np.sum(coef_ ** 2)) +
                             logdet_sigma_ -
                             n_samples * log(2 * np.pi))
                 self.scores_.append(s)


### PR DESCRIPTION
In class Bayesian Ridge, function fit in line 240, under the computation for 's': 
'..np.sum(coef_ ** 2)) - logdet_sigma ' to ' ..np.sum(coef_ ** 2)) + logdet_sigma'

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->


#### What does this implement/fix? Explain your changes.

The formula for 's' in the fit function of Bayesian Ridge appeared to have the wrong sign before logdet_sigma (- instead of +). I noticed this when I got a decreasing score trace in an example and the score (objective to be maximised) should only increase with iterations as we are trying to maximise the objective (s).  




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
